### PR TITLE
💥 Convert package to ESM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Node CI
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        node: [12.20.0, 14.13.1, 16.0.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node }}
+    - name: Install dependencies
+      run: npm install
+    - name: Run tests
+      run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /node_modules/
-/npm-debug.log

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Generates a random path name with the specified `directory` and `template`.
+ *
+ * `template` should be a string where `%s` will be replaced with some random characters (e.g. `'linusu-%s'`). The string should contain `%s` exactly once. If you want to include a literal percent sign, escape it with another one, e.g. `'%%string'` becomes `'%string'`.
+ *
+ * **Important:** This module makes no guarantees on wether there exists a file at the returned path or not. Do not simply write data to the returned path. If you want a random file, use the higher level module [fs-temp](https://github.com/LinusU/fs-temp).
+ *
+ * @returns the generated path
+ */
+export default function randomPath (directory: string, template: string): string
+
+/** Check to see if the template is a valid template accepted by `randomPath`. Throws an error if the template is invalid. */
+export function validateTemplate (template: string): void

--- a/index.js
+++ b/index.js
@@ -1,38 +1,33 @@
-var path = require('path')
-var murmur32 = require('murmur-32')
-var encodeBase32 = require('base32-encode')
+import { join } from 'node:path'
+import encodeBase32 from 'base32-encode'
+import murmur32 from 'murmur-32'
 
-function validateTemplate (template) {
+export function validateTemplate (template) {
   if (typeof template !== 'string') {
     throw new TypeError('template is not a string')
   }
 
-  var re = /(^|[^%])(%%)*%s/
-  var first = re.exec(template)
+  const re = /(^|[^%])(%%)*%s/
+  const first = re.exec(template)
   if (first === null) throw new Error('No replacement token. Template must contain replacement token %s exactly once')
 
-  var pos = first.index + first[0].length
-  var second = re.exec(template.substring(pos))
+  const pos = first.index + first[0].length
+  const second = re.exec(template.substring(pos))
   if (second !== null) throw new Error('Multiple replacement tokens. Template must contain replacement token %s exactly once')
 }
 
 function replaceToken (template, noise) {
-  return template.replace(/%([%s])/g, function ($0, $1) {
-    return ($1 === 's' ? noise : $1)
-  })
+  return template.replace(/%([%s])/g, (_, $1) => ($1 === 's' ? noise : $1))
 }
 
-var invocations = 0
-var localRandom = String(Math.random())
+let invocations = 0
+const localRandom = String(Math.random())
 
-function randomPath (directory, template) {
+export default function randomPath (directory, template) {
   validateTemplate(template)
 
-  var hash = murmur32(localRandom + String(process.pid) + String(++invocations))
-  var noise = encodeBase32(hash, 'Crockford')
+  const hash = murmur32(localRandom + String(process.pid) + String(++invocations))
+  const noise = encodeBase32(hash, 'Crockford')
 
-  return path.join(directory, replaceToken(template, noise))
+  return join(directory, replaceToken(template, noise))
 }
-
-module.exports = randomPath
-module.exports.validateTemplate = validateTemplate

--- a/package.json
+++ b/package.json
@@ -3,14 +3,20 @@
   "version": "0.1.2",
   "license": "MIT",
   "repository": "LinusU/node-random-path",
+  "type": "module",
+  "exports": "./index.js",
   "scripts": {
-    "test": "standard && node test"
+    "test": "standard && node test && ts-readme-generator --check"
   },
   "dependencies": {
-    "base32-encode": "^0.1.0 || ^1.0.0",
-    "murmur-32": "^0.1.0 || ^0.2.0"
+    "base32-encode": "^2.0.0",
+    "murmur-32": "^1.0.0"
   },
   "devDependencies": {
-    "standard": "^14.3.4"
+    "standard": "^16.0.3",
+    "ts-readme-generator": "^0.5.1"
+  },
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -11,8 +11,8 @@ npm install --save random-path
 ## Usage
 
 ```js
-const os = require('os')
-const randomPath = require('random-path')
+import os from 'node:os'
+import randomPath from 'random-path'
 
 const path = randomPath(os.tmpDir(), '%s.txt')
 
@@ -24,24 +24,21 @@ console.log(path)
 
 ### `randomPath(directory, template)`
 
+- `directory` (`string`, required)
+- `template` (`string`, required)
+- returns `string` - the generated path
+
 Generates a random path name with the specified `directory` and `template`.
 
-`template` should be a string where `%s` will be replaced with some random
-characters (e.g. `'linusu-%s'`). The string should contain `%s` exactly once. If
-you want to include a literal percent sign, escape it with another one, e.g.
-`'%%string'` becomes `'%string'`.
+`template` should be a string where `%s` will be replaced with some random characters (e.g. `'linusu-%s'`). The string should contain `%s` exactly once. If you want to include a literal percent sign, escape it with another one, e.g. `'%%string'` becomes `'%string'`.
 
-Returns a string with the path.
+**Important:** This module makes no guarantees on wether there exists a file at the returned path or not. Do not simply write data to the returned path. If you want a random file, use the higher level module [fs-temp](https://github.com/LinusU/fs-temp).
 
-**Important:** This module makes no guarantees on wether there exists a
-file at the returned path or not. Do not simply write data to the
-returned path. If you want a random file, use the higher level module
-[fs-temp](https://github.com/LinusU/fs-temp).
+### `validateTemplate(template)`
 
-### `randomPath.validateTemplate(template)`
+- `template` (`string`, required)
 
-Check to see if the template is a valid template accepted by
-`randomPath`. Throws an error if the template is invalid.
+Check to see if the template is a valid template accepted by `randomPath`. Throws an error if the template is invalid.
 
 ## See also
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
-var assert = require('assert')
-var randomPath = require('./')
+import assert from 'node:assert'
+import randomPath, { validateTemplate } from './index.js'
 
 /* Invalid templates */
 assert.throws(function () {
@@ -15,28 +15,28 @@ assert.throws(function () {
 })
 
 assert.throws(function () {
-  randomPath.validateTemplate('bad template')
+  validateTemplate('bad template')
 })
 
 assert.throws(function () {
-  randomPath.validateTemplate('one: %s, two: %s')
+  validateTemplate('one: %s, two: %s')
 })
 
 assert.throws(function () {
-  randomPath.validateTemplate([1, 2])
+  validateTemplate([1, 2])
 })
 
 /* Valid templates */
-randomPath.validateTemplate('%s')
-randomPath.validateTemplate('%s.txt')
-randomPath.validateTemplate('test-%s')
-randomPath.validateTemplate('test-%s.exe')
-randomPath.validateTemplate('random => %s')
+validateTemplate('%s')
+validateTemplate('%s.txt')
+validateTemplate('test-%s')
+validateTemplate('test-%s.exe')
+validateTemplate('random => %s')
 
 /* Valid path */
-var a = randomPath('/tmp', 'test-%s.txt')
-var b = randomPath('/tmp', 'test-%s.txt')
-var c = randomPath('/tmp', 'test-%s.txt')
+const a = randomPath('/tmp', 'test-%s.txt')
+const b = randomPath('/tmp', 'test-%s.txt')
+const c = randomPath('/tmp', 'test-%s.txt')
 
 assert.notStrictEqual(a, b)
 assert.notStrictEqual(a, c)


### PR DESCRIPTION
Migration Guide:

This relases changes the package from a Common JS module to an EcmaScript module, and drops support for older versions of Node.

- The minimum version of Node.js supported is now: `12.20.0`, `14.13.1`, and `16.0.0`
- The package must now be imported using the native `import` syntax instead of with `require`